### PR TITLE
Fix docker login in docker run (build.sh + test.sh)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -123,7 +123,12 @@ echo "= Building static binaries =" 2>&1 | tee -a ${LOG}
 pushd docker-ce-packaging/static
 
 CONT_NAME=docker-build-static
-docker run -d -v /workspace:/workspace -v ${PATH_SCRIPTS}:${PATH_SCRIPTS} --env PATH_SCRIPTS --env LOG --env DOCKER_SECRET_AUTH --privileged --name ${CONT_NAME} quay.io/powercloud/docker-ce-build ${PATH_SCRIPTS}/build_static.sh
+if [[ ! -z ${DOCKER_SECRET_AUTH+z} ]]
+then
+  docker run -d -v /workspace:/workspace -v ${PATH_SCRIPTS}:${PATH_SCRIPTS} --env PATH_SCRIPTS --env LOG --env DOCKER_SECRET_AUTH --privileged --name ${CONT_NAME} quay.io/powercloud/docker-ce-build ${PATH_SCRIPTS}/build_static.sh
+else
+  docker run -d -v /workspace:/workspace -v ${PATH_SCRIPTS}:${PATH_SCRIPTS} --env PATH_SCRIPTS --env LOG --privileged --name ${CONT_NAME} quay.io/powercloud/docker-ce-build ${PATH_SCRIPTS}/build_static.sh
+fi
 
 status_code="$(docker container wait ${CONT_NAME})"
 if [[ ${status_code} -ne 0 ]]; then


### PR DESCRIPTION
Added a check to see if the variable $DOCKER_SECRET_AUTH is set (necessary for the tests in our local cluster but not on the ppc64le-cloud cluster) in the build.sh and in the test.sh, where we use this variable in docker run commands
And changed path to make it clearer in the test.sh